### PR TITLE
 fix-1/Add expiry and verified minter in signature

### DIFF
--- a/contracts/l2/Types.sol
+++ b/contracts/l2/Types.sol
@@ -42,7 +42,7 @@ struct ExtendExpiryContext {
 }
 
 bytes32 constant EXTEND_EXPIRY_CONTEXT = keccak256(
-    "ExtendExpiryContext(bytes32 node,uint256 expiry,uint256 price,uint256 fee,address paymentReceiver,uint256 nonce,uint256 signatureExpiry)"
+    "ExtendExpiryContext(bytes32 node,uint256 expiry,uint256 price,uint256 fee,address paymentReceiver,uint256 signatureExpiry)"
 );
 
 enum ExpirableType {

--- a/contracts/l2/Types.sol
+++ b/contracts/l2/Types.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 bytes32 constant MINT_CONTEXT = keccak256(
-    "MintContext(string label,bytes32 parentNode,address owner,uint256 price,uint256 fee,address paymentReceiver,uint256 expiry,uint256 nonce)"
+    "MintContext(string label,bytes32 parentNode,address owner,uint256 price,uint256 fee,address paymentReceiver,uint256 expiry,uint256 signatureExpiry,address verifiedMinter)"
 );
 
 struct MintContext {
@@ -13,11 +13,12 @@ struct MintContext {
     uint256 fee;
     address paymentReceiver;
     uint256 expiry;
-    uint256 nonce;
+    uint256 signatureExpiry;
+    address verifiedMinter;
 }
 
 bytes32 constant FACTORY_CONTEXT = keccak256(
-    "FactoryContext(string tokenName,string tokenSymbol,string label,string TLD,address owner,uint8 parentControl,uint8 expirableType)"
+    "FactoryContext(string tokenName,string tokenSymbol,string label,string TLD,address owner,uint8 parentControl,uint8 expirableType,uint256 signatureExpiry)"
 );
 
 struct FactoryContext {
@@ -28,6 +29,7 @@ struct FactoryContext {
     string label;
     string TLD;
     address owner;
+    uint256 signatureExpiry;
 }
 
 struct ExtendExpiryContext {
@@ -36,11 +38,11 @@ struct ExtendExpiryContext {
     uint256 price;
     uint256 fee;
     address paymentReceiver;
-    uint256 nonce;
+    uint256 signatureExpiry;
 }
 
 bytes32 constant EXTEND_EXPIRY_CONTEXT = keccak256(
-    "ExtendExpiryContext(bytes32 node,uint256 expiry,uint256 price,uint256 fee,address paymentReceiver,uint256 nonce)"
+    "ExtendExpiryContext(bytes32 node,uint256 expiry,uint256 price,uint256 fee,address paymentReceiver,uint256 nonce,uint256 signatureExpiry)"
 );
 
 enum ExpirableType {

--- a/contracts/l2/controller/RegistryExpiryExtender.sol
+++ b/contracts/l2/controller/RegistryExpiryExtender.sol
@@ -47,10 +47,10 @@ abstract contract RegistryExpiryExtender is ReentrancyGuard {
 
         uint256 remainder = msg.value - totalPrice;
         if (remainder > 0) {
-            (bool sentToTreasury, ) = payable(msg.sender).call{
+            (bool remainderSent, ) = payable(msg.sender).call{
                 value: remainder
             }("");
-            require(sentToTreasury, "Could not transfer ETH to msg.sender");
+            require(remainderSent, "Could not transfer ETH to msg.sender");
         }
     }
 


### PR DESCRIPTION
**1. Fixed the issue with unexpired signatures ( added signatureExpiry parameter in MintContext, FactoryContext, ExtendExpiryContext)**
  Removed nonces since they are redundant for keeping re-entrancy/replay attacks, since the signatureExpiry parameter will act as a nonce
   a) For MintContext, when subname is minted if an attacker tries to reuse the same signature/parameters (while its still unexpired), the name will already be minted and the request will fail with "NodeAlreadyMinted"
   b) For ExtendExpiryContext, reusing the same signature will just increase the duration but the fees will be paid so we do not have an issue here ( we would allow anyone to extend a name for a certain price, the same way ENS does ).

**2. Added an additional parameter (verifiedMinter) into a MintContext struct which will be part of signature verification. This will prevent the issue when someone frontruns a subname mint and sets a different resolver data**